### PR TITLE
Update to 0.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python
     - opencensus-context >=0.1.3
-    - google-api-core >=1.0.0, <3.0.0
+    - google-api-core >=1.0.0,<3.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.13" %}
+{% set version = "0.11.2" %}
 
 package:
   name: opencensus
@@ -6,30 +6,36 @@ package:
 
 source:
   url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ version }}.zip
-  sha256: 53183a1f1fe952eaf7150c4d713bd16e580e55c021d5cca47df22ee822490c89
+  sha256: 7835c0f3b1aaddb27aaebf434e1b7866841ff1a9185c4c36200dd0631ca9d06b
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - opencensus-context ==0.1.2
-    - google-api-core >=1.0.0, <2.0.0
+    - python
+    - opencensus-context >=0.1.3
+    - google-api-core >=1.0.0, <3.0.0
 
 test:
   imports:
     - opencensus
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/census-instrumentation/opencensus-python
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
   summary: OpenCensus - A stats collection and distributed tracing framework
   description: |
     OpenCensus makes getting critical telemetry out of your services easy and seamless.


### PR DESCRIPTION
Similar to `opencensus-context`, this package was recently deprecated but we need the last updated version for `ray`.