### PR TITLE
Update to 0.11.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.11.2" %}
+{% set version = "0.11.3" %}
 
 package:
   name: opencensus
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/census-instrumentation/opencensus-python/archive/v{{ version }}.zip
-  sha256: 7835c0f3b1aaddb27aaebf434e1b7866841ff1a9185c4c36200dd0631ca9d06b
+  sha256: fe5f55edc468b53418aeb64417fef9f5b6eee61e0f705444749dd008f112a75d
 
 build:
   number: 0
@@ -45,7 +45,7 @@ about:
     or highly-distributed microservices.
     OpenCensus started at Google but is now developed by a broad community of service
     developers, cloud vendors, and community contributors.
-    OpenCensus isn’t tied to any particular vendor’s backend or analysis system.
+    OpenCensus isn't tied to any particular vendor's backend or analysis system.
     This is OpenCensus for Python.
   doc_url: https://opencensus.io/quickstart/python/
   dev_url: https://github.com/census-instrumentation/opencensus-python


### PR DESCRIPTION
Upstream: https://github.com/census-instrumentation/opencensus-python/tree/v0.11.3

Channel: defaults