### PR TITLE
opencensus 0.11.3 - Rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,14 @@ requirements:
     - python
     - opencensus-context >=0.1.3
     - google-api-core >=1.0.0,<3.0.0
+    # Added six because it is a dependency despite not being mentioned upstream for this version of opencensus
+    - six ~= 1.16
 
 test:
   imports:
     - opencensus
+    # Check that six is available
+    - opencensus.metrics.export.metric_descriptor
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: fe5f55edc468b53418aeb64417fef9f5b6eee61e0f705444749dd008f112a75d
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
opencensus 0.11.3 

**Destination channel:** Defaults

### Links

- [PKG-6148]
- dev_url:        https://github.com/census-instrumentation/opencensus-python/tree/v0.11.3

### Explanation of changes:

- Added `six ~= 1.16` as a dependency. This is needed even though it is not mentioned upstream for this [version](https://github.com/census-instrumentation/opencensus-python/blob/v0.11.3/setup.py#L44). It was added [later](https://github.com/census-instrumentation/opencensus-python/commit/927b75048424bf500a84e82f9c5d8ef8279a3c37).
- Added `import` test to check the error that was caused by the missing `six` is fixed.


[PKG-6148]: https://anaconda.atlassian.net/browse/PKG-6148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ